### PR TITLE
:bug: [Fix]: remove pm2 logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "pm2 start dist/main.js",
+    "start:prod": "pm2 start dist/main.js -o /dev/null -e /dev/null",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Description

- winston logger이외에 pm2 log 쌓이는 문제.
- /root에 쌓이고 있어서 EFS모듈에 로그되고있는 winston log와 중복되는 역할을 함.


<br>

## 해결

- pm2 실행 옵션 중, configuration file과 disable logging 파트를 참고함.

<img width="1073" alt="스크린샷 2023-09-01 00 16 24" src="https://github.com/manito42/backend/assets/76278794/c486a16b-fd3c-41d4-a1a8-5624daa18523">


<img width="1068" alt="스크린샷 2023-09-01 00 16 53" src="https://github.com/manito42/backend/assets/76278794/90920bc0-4bbf-4e1c-ac0f-1d2d67a04e47">


<br>

### refs

[pm2 공식문서](https://pm2.keymetrics.io/docs/usage/log-management/)

