### PR TITLE
:sparkles: [Feat]: email from에 42manito 서브도메인 추가.

### DIFF
--- a/src/modules/notification/notification.service.ts
+++ b/src/modules/notification/notification.service.ts
@@ -12,13 +12,11 @@ export class NotificationService {
       to: emails,
       subject: subject,
       html: content,
+      from: 'reservation.42manito.com',
     });
     this.logger.log(`Sent mail to ${emails}`);
   }
 
-  /**
-   * NOTE: 현재는 메일만 전송함.
-   */
   async notify(sendTo: Array<User>, subject: string, content: string) {
     const emails = sendTo.map((user) => user.email);
     await this.notifyByMail(emails, subject, content);


### PR DESCRIPTION
[Domain and "From" address considerations](https://docs.aws.amazon.com/ses/latest/dg/tips-and-best-practices.html)

> 이메일을 보내는 주소에 대해 신중하게 생각하십시오. "보낸 사람" 주소는 수신자가 보는 첫 번째 정보 중 하나이므로 지속적인 첫인상을 남길 수 있습니다. 또한 일부 ISP는 귀하의 평판을 "보낸 사람" 주소와 연관시킵니다.

> 다양한 유형의 통신에 하위 도메인을 사용하는 것을 고려해보세요. 예를 들어 example.com 도메인에서 이메일을 보내고 마케팅 메시지와 거래 메시지를 모두 보낼 계획이라고 가정해 보겠습니다. example.com 에서 모든 메시지를 보내는 대신 , Marketing.example.com 과 같은 하위 도메인에서 마케팅 메시지를 보내고 , Orders.example.com 과 같은 하위 도메인에서 거래 메시지를 보내세요.. 고유한 하위 도메인은 고유한 평판을 형성합니다. 하위 도메인을 사용하면 마케팅 커뮤니케이션이 스팸 트랩에 걸리거나 콘텐츠 필터가 실행되는 경우 평판이 손상될 위험이 줄어듭니다.

> 많은 수의 메시지를 보내려는 경우 sender@hotmail.com 과 같은 ISP 기반 주소에서 해당 메시지를 보내지 마십시오 . ISP가 sender@hotmail.com 에서 오는 대량의 메시지를 발견한 경우 해당 이메일은 귀하가 소유한 아웃바운드 이메일 전송 도메인에서 오는 이메일과 다르게 처리됩니다.

> 도메인 등록 기관과 협력하여 도메인에 대한 WHOIS 정보가 정확한지 확인하세요. 정직하고 최신의 WHOIS 기록을 유지하는 것은 귀하가 투명성을 중시한다는 것을 보여주며 사용자가 귀하의 도메인이 합법적인지 여부를 신속하게 식별할 수 있게 해줍니다.

> no-reply@example.com 과 같은 무응답 주소를 "보낸 사람" 또는 "답장 받는 사람" 주소로 사용하지 마세요 . no-reply@ 이메일 주소를 사용하면 수신자에게 귀하에게 연락할 방법을 제공하지 않으며 그들의 피드백에 관심이 없다는 명확한 메시지를 보냅니다.

