### PR TITLE
🐛 [Fix] socialLink

### DIFF
--- a/src/database/repository/mentorProfile.repository.ts
+++ b/src/database/repository/mentorProfile.repository.ts
@@ -128,6 +128,7 @@ export class MentorProfileRepository {
       if (data.categories.length == 0) isHide = true;
       // 업데이트할 해시태그가 0개인 경우
       if (data.hashtags.length == 0) isHide = true;
+      if (data.socialLink == null) data.socialLink = '';
 
       return prisma.mentorProfile.update({
         where: {


### PR DESCRIPTION
#141 에서 mentorProfileUpdate repository에서
 socialLink null로 받을 때 '' 빈 문자열로 바꾸는 코드가 생략되는 문제 발생.